### PR TITLE
Fix crash for Rails 3 if gem is loaded before Rails is initialized

### DIFF
--- a/lib/error_stalker/client.rb
+++ b/lib/error_stalker/client.rb
@@ -57,6 +57,6 @@ end
 logfile = File.join(Dir.tmpdir, "exceptions.log")
 
 # let's put this in a better place if we're using rails
-logfile = Rails.root + 'log/exceptions.log' if defined?(Rails)
+logfile = Rails.root + 'log/exceptions.log' if defined?(Rails) && Rails.root
 
 ErrorStalker::Client.backend = ErrorStalker::Backend::LogFile.new(logfile)


### PR DESCRIPTION
don't crash if error_stalker is loaded before Rails is initialized (Rails 3 default)

By default in Rails 3, Bundler.require is called before the app is initialized. "Rails" is defined, but "Rails.root" is nil.  This gem crashes if Rails is defined, but Rails.root is nil.
